### PR TITLE
Test enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ matrix:
 
 before_script:
   # --ignore-platform-reqs, because https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/2722
-  - composer update -n --prefer-dist --ignore-platform-reqs
-  - composer require satooshi/php-coveralls dev-master --ignore-platform-reqs
+  - composer update -n --prefer-dist
+  - composer require php-coveralls/php-coveralls "^2.0"
 
 script:
   - phpdbg -qrr vendor/bin/phpunit --coverage-text --coverage-clover build/logs/clover.xml

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,9 @@
             "src/functions.php"
         ]
     },
-    "require": {},
+    "require": {
+        "php": ">=7.0"
+    },
     "require-dev": {
         "phpunit/phpunit": "^6",
         "friendsofphp/php-cs-fixer": "^2.3"

--- a/test/LinkTest.php
+++ b/test/LinkTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Kelunik\LinkHeaderRfc5988\Test;
+
+use Kelunik\LinkHeaderRfc5988\Link;
+use PHPUnit\Framework\TestCase;
+
+class LinkTest extends TestCase {
+    public function testConstructor() {
+        $link = new Link("http://domain.name", ["param" => "value"]);
+        $params = $link->getParams();
+
+        $this->assertSame("http://domain.name", $link->getUri());
+        $this->assertSame("value", $link->getParam("param"));
+        $this->assertSame("value", $params["param"]);
+    }
+}

--- a/test/ParseTest.php
+++ b/test/ParseTest.php
@@ -17,6 +17,7 @@ class ParseTest extends TestCase {
         $this->assertSame("previous chapter", $link->getParam("title"));
         $this->assertInstanceOf(Link::class, $links->getByRel("previous"));
         $this->assertNull($links->getByRel("next"));
+        $this->assertCount(0, $links->getAllByRel("next"));
     }
 
     public function testRfc5988Example2() {
@@ -28,6 +29,7 @@ class ParseTest extends TestCase {
         $this->assertSame("http://example.net/foo", $link->getParam("rel"));
         $this->assertInstanceOf(Link::class, $links->getByRel("http://example.net/foo"));
         $this->assertNull($links->getByRel("foobar"));
+        $this->assertCount(0, $links->getAllByRel("foobar"));
     }
 
     public function testRfc5988Example3() {
@@ -48,6 +50,7 @@ class ParseTest extends TestCase {
         $this->assertInstanceOf(Link::class, $links->getByRel("previous"));
         $this->assertInstanceOf(Link::class, $links->getByRel("next"));
         $this->assertNull($links->getByRel("foobar"));
+        $this->assertCount(0, $links->getAllByRel("foobar"));
     }
 
     public function testRfc5988Example4() {
@@ -60,5 +63,23 @@ class ParseTest extends TestCase {
         $this->assertInstanceOf(Link::class, $links->getByRel("http://example.net/relation/other"));
         $this->assertInstanceOf(Link::class, $links->getByRel("start"));
         $this->assertNull($links->getByRel("foobar"));
+        $this->assertCount(0, $links->getAllByRel("foobar"));
+    }
+
+    public function linkParamsProvider() {
+        return [
+            ["http://example.com", 0],
+            ["[http://example.org/]; rel=\"start http://example.net/relation/other\"", 0],
+            ["<http://example.org/>; rel==\"start http://example.net/relation/other\"", 1],
+        ];
+    }
+
+    /**
+     * @dataProvider linkParamsProvider
+     */
+    public function testParseLinksOnLinkParams($link, $expectedCount) {
+        $links = parseLinks($link);
+
+        $this->assertCount($expectedCount, $links->getAll());
     }
 }


### PR DESCRIPTION
# Changed log
- Remove option ```--ignore-platform-reqs``` because it need the composer to check the dependency.
- Use the ```php-coveralls/php-coveralls``` to install the ```^2.0```.
- Add more tests.